### PR TITLE
Docs: auth consistency, terminal/tmux, workflow and config stubs

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) 2025 Human Loop Ventures, LLC. All rights reserved.
+Use of this source code is governed by the Business Source License 1.1
+included in the LICENSE file at the root of this repository.
+-->
+
+# Configuration
+
+*TBD — This guide will cover environment variables, configuration files, and runtime settings for customizing your MASON setup.*

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,7 +19,7 @@ You'll need:
 | **Disk** | 10GB free | 20GB+ |
 | **OS** | macOS, Linux, or Windows (WSL2) | macOS or Linux |
 
-You'll also need an **Anthropic API key**. MASON agents are powered by Claude — grab your key from [console.anthropic.com](https://console.anthropic.com).
+You'll also need access to **Claude** — either an Anthropic API key or a Claude subscription. MASON agents are powered by Claude.
 
 ## Step 1: Get the Code
 
@@ -54,7 +54,7 @@ The wizard walks you through six steps:
 
 1. **Accept the User Agreement** — Read through and confirm the three acknowledgments (simulation platform, no-harm commitment, no professional advice)
 2. **Choose your auth method** — API key or subscription-based authentication
-3. **Enter your Claude credentials** — Paste your Anthropic API key
+3. **Enter your Claude credentials** — Paste your Anthropic API key or sign in with your Claude subscription
 4. **Set up your profile** — Your name and what to call your concierge
 5. **Claude terminal authentication** — Verifies your credentials work
 6. **Launch** — Everything starts up
@@ -84,6 +84,7 @@ Your agents are working. You can:
 
 - **Watch them coordinate** in the shared project channels
 - **Jump into any channel** to talk directly with an individual agent
+- **Open the terminal** to watch agents think and work in real time — each agent runs in its own tmux session where you can see exactly what they're doing
 - **Give direction** when you want to steer the work
 - **Sit back and observe** how they tackle problems as a team
 
@@ -126,9 +127,9 @@ docker stats
 
 Try increasing Docker's memory limit in Docker Desktop settings.
 
-### API key errors
+### Authentication errors
 
-If the wizard reports an API key error, double-check that you're using a valid Anthropic API key. You can verify your key at [console.anthropic.com](https://console.anthropic.com).
+If the wizard reports a credentials error, double-check your setup. For API keys, verify yours at [console.anthropic.com](https://console.anthropic.com). For Claude subscriptions, make sure you're signed in and your subscription is active.
 
 ### Port conflicts
 
@@ -161,5 +162,6 @@ Once your simulation is running:
 1. **Explore the channels** — Each agent has their own space, plus shared project channels
 2. **Start small** — Get a feel for how agents collaborate before going big
 3. **Observe and participate** — Jump in when you have questions, or sit back and watch how the team works through problems together
+4. **Level up** — Check out the **[Workflows Guide](WORKFLOWS.md)** for tips on running projects, managing your team, and getting the most out of MASON's tools
 
 Welcome to MASON. Let's see what your team can do.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Think of it as spinning up a simulated startup team that coordinates, communicat
 - **A concierge who gets it** — Connie interviews you about your project, then assembles the right team for the job
 - **Specialized agents** — Engineers, a designer, a PM, a QA lead... each one focused on what they do best
 - **Real collaboration** — Agents talk to each other, review each other's work, and coordinate without you micromanaging
-- **Familiar tools** — Agents use the same tools real teams use: Git, chat, code editors
+- **Familiar tools** — Agents use the same tools real teams use: Git, chat, terminal
 - **One command to start** — `./scripts/masonctl start` and you're up
 
 ## Quick Start
@@ -29,7 +29,7 @@ cd mason-teams
 ./scripts/masonctl start
 ```
 
-Then open **http://localhost:8080** to run the setup wizard. Enter your Anthropic API key, configure your profile, and meet Connie — she'll take it from there.
+Then open **http://localhost:8080** to run the setup wizard. Bring your own Anthropic API key or use your Claude subscription — the wizard lets you choose. Configure your profile, and meet Connie — she'll take it from there.
 
 For the full walkthrough, see the **[Getting Started Guide](GETTING_STARTED.md)**.
 
@@ -39,7 +39,7 @@ MASON runs everything inside a single container — agents, chat, code tools, th
 
 - A **role** (engineer, designer, PM, etc.)
 - A **personality** and communication style
-- Access to **shared tools** (Git, Mattermost chat, code editors)
+- Access to **shared tools** (Git, Mattermost chat, terminal)
 - The ability to **collaborate** with other agents and with you
 
 You describe a project. Connie figures out what kind of team you need, spins them up, and they get to work. You observe and participate through the same chat channels they use.
@@ -50,13 +50,13 @@ You describe a project. Connie figures out what kind of team you need, spins the
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (includes Docker CLI and everything you need)
 - 16GB+ RAM recommended (agents need room to think)
-- An Anthropic API key (agents are powered by Claude)
+- An Anthropic API key or Claude subscription (agents are powered by Claude)
 
 ## License
 
 MASON is licensed under the [Business Source License 1.1](LICENSE).
 
-**Free for non-production use**, or production use with fewer than 5 concurrent simulated agents. Need more? [Get in touch](mailto:david@shindeiru.com) about commercial licensing.
+**Free for non-production use**, or production use with fewer than 5 concurrent simulated agents. Need more? [Get in touch](mailto:info@masonteams.com) about commercial licensing.
 
 ## Links
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -1,0 +1,155 @@
+<!--
+Copyright (c) 2025 Human Loop Ventures, LLC. All rights reserved.
+Use of this source code is governed by the Business Source License 1.1
+included in the LICENSE file at the root of this repository.
+-->
+
+# MASON Workflows
+
+A guide to getting the most out of MASON — from your first conversation with Connie to running a full agent team like a seasoned operator.
+
+---
+
+## 1. Basic — Your First Simulation
+
+*Getting started: meet Connie, spin up a team, and find your way around.*
+
+### The Interview
+
+- What Connie asks and why it matters
+- How your answers shape the team she builds
+- Tips for describing your project (specific vs broad, what works best)
+
+### Your First Team
+
+- What to expect when agents come online
+- How to find your agents (channels, DMs, who's who)
+- The difference between watching and participating
+
+### Using Forgejo
+
+- What Forgejo is and why it's in the container
+- How agents track changes to docs and plans
+- Browsing the repo: seeing what your team has produced
+- Issues as a lightweight way to track decisions and progress
+
+### First Steps Checklist
+
+- [ ] Complete the setup wizard
+- [ ] Let Connie interview you
+- [ ] Explore the Mattermost channels
+- [ ] Check Forgejo to see agent commits
+- [ ] Give your team a small task and watch how they coordinate
+
+---
+
+## 2. Intermediate — Running a Real Project
+
+*Your team is up. Now how do you actually get work done?*
+
+### Getting a Project Started
+
+- How to frame a project for your agents
+- Breaking big ideas into agent-sized pieces
+- When to let agents self-organize vs giving explicit direction
+
+### Team Structure
+
+- Identifying a leader agent (who merges PRs, who manages)
+- Defining responsibilities — who owns what
+- How agents hand off work to each other
+- The role of code review between agents
+
+### Memory Systems — When to Use What
+
+- **User memory** (`~/.claude/`) — Your preferences, global settings, things that apply everywhere
+- **Project memory** (`.claude/CLAUDE.md`) — Architecture, conventions, team norms for this project
+- **Memshot** (`/memshot`) — Quick snapshots of current state, for crash recovery or handoffs
+- **Agent memory** (`memory_store`) — Learnings and gotchas that other agents should know
+- **Obsidian diary** — Session logs for human review
+
+### Decision Tree
+
+```
+Where does this info belong?
+├─ Only this project? → Project CLAUDE.md
+├─ All my sessions? → User CLAUDE.md
+├─ Another agent needs it? → memory_store
+├─ I need to recover from a crash? → memshot
+└─ Human needs to review later? → Obsidian diary
+```
+
+---
+
+## 3. Advanced — Mixed Control
+
+*Terminal commands and Mattermost messages — two ways to talk to your team, each with strengths.*
+
+### Terminal vs Mattermost — When to Use Which
+
+- **Terminal** (direct Claude session) — Precise instructions, code-heavy work, debugging, when you need control
+- **Mattermost** (chat) — Broad direction, team-wide announcements, async work, when you want agents to self-organize
+- **Mixing both** — Using terminal for the agent you're paired with, MM for the rest of the team
+
+### My Preference
+
+<!-- dpark: fill in your actual workflow preferences here -->
+
+- When I reach for terminal vs when I use MM
+- How I switch between them during a session
+- Why I prefer [X] for [Y] situations
+
+### Agent Lifecycle Management
+
+- Starting and stopping individual agents
+- Reloading an agent when context gets stale
+- Office hours mode — polling, monitoring, autonomous work
+- Beepme — getting an agent's attention when you need them in a channel
+
+### Tmux Session Management
+
+- How agents live in tmux panes
+- Sending commands to specific agents
+- Monitoring multiple agents at once
+- When to kill and respawn vs reload
+
+---
+
+## 4. Beyond — The Full Toolkit
+
+*How an experienced operator uses MASON's tools together to work on real tasks and ideas.*
+
+### The Operator's Workflow
+
+<!-- dpark: this section is your voice — how YOU actually work with agents -->
+
+- How I think about tasks before assigning them
+- My process for going from idea → spec → implementation
+- How I use agents differently for exploration vs execution
+- When I do it myself vs when I delegate to agents
+
+### Tools in Concert
+
+- **Speckit workflow** — constprep → specify → clarify → plan → tasks → implement
+- **Autopilot** — When to let agents run the full workflow autonomously
+- **Code review loops** — How agents review each other's work before merging
+- **Cross-agent collaboration** — Memchat, beepme, shared channels
+
+### Patterns I've Found Useful
+
+<!-- dpark: real examples from your experience -->
+
+- Pattern: "Scout then build" — use one agent to explore, another to implement
+- Pattern: "Terminal for precision, MM for direction"
+- Pattern: "Let them argue" — when agent disagreement produces better results
+- Pattern: [more to come]
+
+### Anti-Patterns
+
+- What doesn't work well
+- Common mistakes when starting out
+- When to pull the plug and redirect
+
+---
+
+*This guide is a work in progress. It'll grow as we learn more about what works.*


### PR DESCRIPTION
## Summary

- Consistently mention Claude subscription alongside API key in README and GETTING_STARTED
- Replace "code editors" with "terminal" (accurate to what's in the container)
- Update contact email to info@masonteams.com
- Add terminal/tmux observation to Step 6 (Collaborate) — users can watch agents think in real time
- Broaden "API key errors" troubleshooting to "Authentication errors" covering both auth methods
- Add link to Workflows Guide in What's Next section
- Add WORKFLOWS.md stub with 4 tiers (Basic, Intermediate, Advanced, Beyond)
- Add CONFIGURATION.md placeholder for future runtime config documentation

## Test plan
- [ ] Verify all links resolve correctly
- [ ] Review auth language for consistency across both docs
- [ ] Confirm WORKFLOWS.md and CONFIGURATION.md render properly

Generated with [Claude Code](https://claude.com/claude-code)