### PR TITLE
Update docs for masonctl TLS and token auth

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,7 +25,7 @@ Set these before running `./scripts/masonctl start` to override defaults.
 MASON_PORT_WEB=9080 MASON_PORT_MM=9065 ./scripts/masonctl start
 ```
 
-Then open `http://localhost:9080` for the setup wizard.
+Then open `https://localhost:9080` for the setup wizard.
 
 ## Ports
 
@@ -33,7 +33,7 @@ MASON exposes these ports from the container:
 
 | Port | Service | What it's for |
 |------|---------|---------------|
-| `8080` | Web UI | Setup wizard and dashboard |
+| `8080` | Web UI | Setup wizard and dashboard (HTTPS, token auth) |
 | `8065` | Mattermost | Team chat — where you talk to agents |
 | `3000` | Forgejo | Git repositories and code collaboration |
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -36,18 +36,41 @@ MASON runs as a single container — agents, chat, code tools, everything inside
 ./scripts/masonctl start
 ```
 
-The image will be pulled automatically on first run. Check that everything's up:
+On first run, `masonctl` will:
+- Pull the MASON container image
+- Generate a self-signed TLS certificate for the dashboard
+- Create an authentication token for secure access
+
+Check that everything's up:
 
 ```bash
 ./scripts/masonctl status
 ```
 
+### Log in to the Dashboard
+
+The dashboard runs over HTTPS with token-based authentication. To get your login token:
+
+```bash
+./scripts/masonctl token
+```
+
+Or open the login page directly:
+
+```bash
+./scripts/masonctl login
+```
+
+This prints the token and opens the dashboard in your browser.
+
+> **Note:** Your browser will show a certificate warning on first visit because the TLS certificate is self-signed. This is expected — see [Browser certificate warning](#browser-certificate-warning) below.
+
 ## Step 3: Run the Setup Wizard
 
-Open your browser and go to:
+Once logged in, the dashboard opens to:
 
 ```
-http://localhost:8080
+https://localhost:8080
 ```
 
 The wizard walks you through seven steps. Your progress is saved automatically — if you close your browser, you'll pick up where you left off.
@@ -154,6 +177,8 @@ The simulation runs as long as the container is up. Agents keep working, collabo
 | `./scripts/masonctl stop` | Stop the container |
 | `./scripts/masonctl restart` | Restart everything |
 | `./scripts/masonctl status` | Check what's running |
+| `./scripts/masonctl token` | Print your dashboard auth token |
+| `./scripts/masonctl login` | Print token and open dashboard in browser |
 | `./scripts/masonctl logs` | View logs |
 | `./scripts/masonctl logs -f` | Follow logs in real time |
 | `./scripts/masonctl update` | Pull latest image and restart |
@@ -201,7 +226,7 @@ If port 8080 or 8065 is already in use, set custom ports:
 MASON_PORT_WEB=9080 MASON_PORT_MM=9065 ./scripts/masonctl start
 ```
 
-Then open `http://localhost:9080` for the wizard.
+Then open `https://localhost:9080` for the wizard.
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ cd mason-teams
 ./scripts/masonctl start
 ```
 
-Then open **http://localhost:8080** to run the setup wizard. Bring your own Anthropic API key or use your Claude subscription — the wizard lets you choose. Configure your profile, and meet Connie — she'll take it from there.
+Then log in to the dashboard:
+
+```bash
+./scripts/masonctl login
+```
+
+This prints your auth token and opens **https://localhost:8080** in your browser. Bring your own Anthropic API key or use your Claude subscription — the wizard lets you choose. Configure your profile, and meet Connie — she'll take it from there.
 
 For the full walkthrough, see the **[Getting Started Guide](GETTING_STARTED.md)**.
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -122,7 +122,7 @@ MASON exposes several ports out of the box:
 
 | Port | Service | Purpose |
 |------|---------|---------|
-| 8080 | Setup Wizard | Initial configuration and onboarding |
+| 8080 | Setup Wizard | Initial configuration and onboarding (HTTPS, token auth) |
 | 8065 | Mattermost | Team chat — where you talk to your agents |
 | 3000 | Forgejo | Git forge — repos, issues, pull requests |
 | 7681 | ttyd | Web terminal — browser-based access to the container |


### PR DESCRIPTION
## Summary

- Update GETTING_STARTED.md: Add Step 2 login flow (`masonctl token`, `masonctl login`), change wizard URL to HTTPS, add token/login to commands table
- Update README.md: Quick Start now includes `masonctl login` step, URL changed to HTTPS
- Update CONFIGURATION.md: Custom port URL changed to HTTPS, port table notes HTTPS+auth
- Update WORKFLOWS.md: Port table notes HTTPS+auth on 8080

Per Jake's request — docs needed updating for the new TLS + auth setup where `masonctl start` auto-generates a cert and token.

## Test plan

- [ ] Verify all URLs use https:// where dashboard is referenced
- [ ] Verify masonctl login/token commands are documented
- [ ] Confirm no stale http://localhost:8080 references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)