### PR TITLE
Update docs for v1.0.0 features: TLS, Swagger, error-report, CC pinning

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -34,8 +34,8 @@ MASON exposes these ports from the container:
 | Port | Service | What it's for |
 |------|---------|---------------|
 | `8080` | Web UI | Setup wizard and dashboard (HTTPS, token auth) |
-| `8065` | Mattermost | Team chat — where you talk to agents |
-| `3000` | Forgejo | Git repositories and code collaboration |
+| `8065` | Mattermost | Team chat — where you talk to agents (HTTPS when TLS enabled) |
+| `3000` | Forgejo | Git repositories and code collaboration (HTTPS when TLS enabled) |
 
 All three can be customized with the `MASON_PORT_*` environment variables above.
 
@@ -102,6 +102,31 @@ The setup wizard collects your preferences and stores them automatically. You do
 | Terms acceptance | `/data/config/setup-progress.json` | User Agreement acknowledgments and timestamps |
 
 **Progress is saved automatically.** If you close your browser mid-setup, you'll resume where you left off when you come back. Going back to earlier steps preserves your previous inputs.
+
+## API Documentation
+
+MASON includes interactive API documentation via Swagger UI. Once the container is running, you can explore and test endpoints from your browser:
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| Mason Server | `https://localhost:8080/swagger/` | Dashboard and setup API |
+| Agent Daemon | `http://localhost:9090/swagger/` | Agent lifecycle and messaging API |
+
+> **Note:** The daemon API (port 9090) is internal to the container and not exposed to the host by default. Access it from inside the container or by adding `-p 9090:9090` to your `docker run` command.
+
+## Claude Code Version
+
+MASON ships with a certified version of Claude Code (currently **v2.1.77**) to ensure consistent behavior across installations. This version is installed automatically during the setup wizard.
+
+If you decline the wizard install, the dashboard shows the certified version number with a manual install option. We recommend using the bundled version rather than installing the latest independently, as agent templates and commands are tested against the certified version.
+
+## Agent Configuration
+
+MASON pre-configures Claude Code with sensible defaults for agent workloads:
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `effortLevel` | `medium` | Thinking effort preset — balances quality and speed. Agents won't prompt you to choose on first start. |
 
 ## Advanced Configuration
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -248,6 +248,8 @@ Check the [Changelog](CHANGELOG.md) for what's new.
 
 ## Getting Help
 
+**Something not working?** Ask Connie to run `/error-report` — she'll gather diagnostics and help you create a bug report you can file on GitHub.
+
 - **Issues**: [github.com/Mason-Teams/mason-teams/issues](https://github.com/Mason-Teams/mason-teams/issues)
 - **Email**: [info@masonteams.com](mailto:info@masonteams.com)
 - **Website**: [masonteams.com](https://masonteams.com)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You describe a project. Connie figures out what kind of team you need, spins the
 MASON takes a secure-by-default approach to localhost development:
 
 - **Token authentication** — Dashboard access requires a 32-character token generated on first start (`masonctl token` to retrieve)
-- **TLS encrypted** — Dashboard serves HTTPS with an auto-generated certificate
+- **TLS encrypted** — All services (Dashboard, Mattermost, Forgejo) serve HTTPS with a shared auto-generated certificate
 - **Minimal exposure** — Only 3 ports are mapped to the host; all internal services are localhost-only inside the container
 - **Read-only credentials** — Host credentials are mounted read-only into the container
 - **Locked-down permissions** — Token and TLS key files are mode 0600

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,18 +73,14 @@ Only three ports are mapped from the container to the host:
 | Port | Service | Protocol | Auth |
 |------|---------|----------|------|
 | 8080 | Dashboard | HTTPS (TLS) | Token required |
-| 8065 | Mattermost | HTTP | MM login required |
-| 3000 | Forgejo | HTTP | Forgejo login required |
+| 8065 | Mattermost | HTTPS (TLS) | MM login required |
+| 3000 | Forgejo | HTTPS (TLS) | Forgejo login required |
+
+All three services share the same self-signed TLS certificate. When TLS certificates are present (`~/.mason/tls/`), all services run HTTPS automatically. Without certificates (e.g., plain `docker run`), all services fall back to HTTP.
 
 All other internal services bind to `127.0.0.1` inside the container and are **not accessible from the host**.
 
-### Adding TLS to Mattermost & Forgejo
-
-Mattermost and Forgejo serve HTTP by default. For HTTPS:
-
-- Use a reverse proxy (nginx, caddy, traefik) on the host
-- Or configure their native TLS settings via their admin UIs
-- For localhost-only use, HTTP is acceptable
+> **Note:** If you're using `curl` against any MASON service with self-signed certs, add the `-k` flag to skip certificate verification: `curl -k https://localhost:8080/...`
 
 ## File Permissions
 

--- a/SKILLSANDCOMMANDS.md
+++ b/SKILLSANDCOMMANDS.md
@@ -29,12 +29,15 @@ These are exclusive to Connie, your team's concierge. They handle team-level orc
 | Command | Description |
 |---------|-------------|
 | `/change-password` | Change your Mattermost and Forgejo passwords — handles secure credential exchange via DM |
+| `/error-report` | Generate a diagnostic report for filing bug reports — gathers system info, logs, and agent status into a formatted report |
 | `/spawn-team` | Initialize and start a full team — provisions all agents defined in the team configuration after the interview |
 | `/spawn-agent` | Initialize and start a single agent — creates workspace, MCP config, Mattermost account, tmux session, and directory registration |
 | `/shutdown-team` | Gracefully shut down a team — stops agents, cleans up resources, optionally removes all data |
 | `/mm-admin` | Mattermost administration — create teams, channels, users, generate tokens, manage memberships (wraps `mm-admin.py`) |
 | `/officehours` | Concierge office hours cycle — includes interview processing and agent health checks alongside message handling |
 | `/officehours-loop` | Continuous concierge office hours — polling-based alternative that runs on a timer from the terminal |
+
+**Reporting issues:** If something goes wrong, ask Connie to run `/error-report`. She'll walk you through describing the problem, gather diagnostic information (system info, logs, agent status), and produce a formatted report you can paste directly into a [GitHub issue](https://github.com/Mason-Teams/mason-teams/issues). Connie can also walk you through setting up the `gh` CLI if you'd like to file issues from the command line.
 
 **How Connie uses these:** After your interview, Connie runs `/spawn-team` to bring everyone online. From there, the daemon triggers `/officehours` whenever you post in Mattermost, keeping Connie responsive to your messages and monitoring agent health. If you need to add someone mid-project, `/spawn-agent` handles individual provisioning.
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -123,8 +123,8 @@ MASON exposes several ports out of the box:
 | Port | Service | Purpose |
 |------|---------|---------|
 | 8080 | Setup Wizard | Initial configuration and onboarding (HTTPS, token auth) |
-| 8065 | Mattermost | Team chat — where you talk to your agents |
-| 3000 | Forgejo | Git forge — repos, issues, pull requests |
+| 8065 | Mattermost | Team chat — where you talk to your agents (HTTPS when TLS enabled) |
+| 3000 | Forgejo | Git forge — repos, issues, pull requests (HTTPS when TLS enabled) |
 | 7681 | ttyd | Web terminal — browser-based access to the container |
 
 If your agents spin up additional services inside the container (a dev server, an API, etc.), you'll need to expose those ports. You can do this when starting the container:


### PR DESCRIPTION
## Summary

Docs updates for 6 items from recent PRs (#457-#469):

- **TLS on all services** — SECURITY.md port table updated (all HTTPS), removed "Adding TLS to MM/Forgejo" section (now automatic), added curl `-k` note. Updated port tables in CONFIGURATION.md and WORKFLOWS.md.
- **Swagger UI** — New "API Documentation" section in CONFIGURATION.md with URLs for server + daemon
- **Claude Code version pinning** — New section in CONFIGURATION.md documenting certified version (v2.1.77)
- **Thinking effort preset** — New "Agent Configuration" section noting effortLevel: medium default
- **`/error-report` command** — Added to concierge commands table in SKILLSANDCOMMANDS.md with usage description. Added "ask Connie" note to Getting Help in GETTING_STARTED.md
- **README** — Updated security bullet to reflect all services have TLS

## Test plan

- [ ] SECURITY.md port table shows HTTPS for all 3 services
- [ ] CONFIGURATION.md Swagger URLs render correctly
- [ ] SKILLSANDCOMMANDS.md /error-report appears in concierge table
- [ ] GETTING_STARTED.md Getting Help section mentions /error-report

🤖 Generated with [Claude Code](https://claude.com/claude-code)