### PR TITLE
Document how to watch agents work via docker exec + tmux

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -173,7 +173,7 @@ Your agents are working. You can:
 
 - **Watch them coordinate** in the shared project channels
 - **Jump into any channel** to talk directly with an individual agent
-- **Open the terminal** to watch agents think and work in real time — each agent runs in its own tmux session where you can see exactly what they're doing
+- **Open the terminal** to watch agents think and work in real time — run `docker exec -it mason bash` then `tmux a -t mason-connie` (or any agent's session) to see exactly what they're doing. See the [Workflows Guide](WORKFLOWS.md#watching-agents-work) for details.
 - **Give direction** when you want to steer the work
 - **Sit back and observe** how they tackle problems as a team
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -273,12 +273,57 @@ docker run --memory=32g --cpus=12 -p 8080:8080 -p 8065:8065 -p 3000:3000 ...
 - Office hours mode — polling, monitoring, autonomous work
 - Beepme — getting an agent's attention when you need them in a channel
 
-### Tmux Session Management
+### Watching Agents Work
 
-- How agents live in tmux panes
-- Sending commands to specific agents
-- Monitoring multiple agents at once
-- When to kill and respawn vs reload
+Every agent runs in its own tmux session inside the container. You can drop in at any time to watch them think, code, and collaborate in real time.
+
+**Get into the container:**
+
+```bash
+docker exec -it mason bash
+```
+
+**List all agent sessions:**
+
+```bash
+tmux ls
+```
+
+You'll see sessions like `mason-connie`, `mason-kenji`, `mason-riley`, etc. — one per agent.
+
+**Attach to a session to watch an agent:**
+
+```bash
+tmux a -t mason-connie
+```
+
+You're now watching Connie's terminal live. You'll see Claude Code running, the agent thinking, reading files, writing code, sending messages — everything in real time.
+
+**Detach without stopping the agent:** Press `Ctrl+B` then `D`. This puts you back in the container shell. The agent keeps working.
+
+**Switch between agents quickly:**
+
+```bash
+# Detach from current, attach to another
+tmux a -t mason-kenji
+```
+
+**View multiple agents at once** (if you're familiar with tmux):
+
+```bash
+# From inside tmux, press Ctrl+B then S to see all sessions
+# Use arrow keys to switch between them
+```
+
+**Exit the container** when you're done watching:
+
+```bash
+exit
+```
+
+> **Tip:** You can also access the container terminal from your browser via ttyd at `http://localhost:7681` — no `docker exec` required.
+
+> **Note:** Watching is read-only observation. You won't interfere with the agent's work by attaching to their session. To actually communicate with agents, use Mattermost.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fill in the placeholder "Tmux Session Management" section in WORKFLOWS.md with actual commands
- Covers: docker exec into container, tmux ls, attaching to agent sessions, detaching, switching between agents, ttyd web terminal alternative
- Update GETTING_STARTED.md "Open the terminal" bullet with actionable commands and link to Workflows guide

## Test plan

- [ ] Verify anchor link `#watching-agents-work` resolves correctly
- [ ] Confirm commands are accurate for the mason container

🤖 Generated with [Claude Code](https://claude.com/claude-code)