### PR TITLE
Add disk breakdown: ~3GB image + growing data

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -17,6 +17,8 @@ You'll need:
 | **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** | v24+ | Latest stable |
 | **RAM** | 8GB | 16GB+ |
 | **Disk** | 10GB free | 20GB+ |
+
+> **Disk breakdown:** The MASON container image is ~3GB. Additional space is needed for agent workspaces, Git repos, chat history, and memory — this grows over time as your team works.
 | **OS** | macOS, Linux, or Windows (WSL2) | macOS or Linux |
 
 You'll also need access to **Claude** — either an Anthropic API key or a Claude subscription. MASON agents are powered by Claude.


### PR DESCRIPTION
Note that the image is ~3GB and workspace data grows over time.