### PR TITLE
Document v1.2.0: safety prompts, MM/Forgejo upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to MASON will be documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-27
+
+### Changed
+- **masonctl safety prompts** — All destructive commands (stop, restart, rebuild, update, rm) now prompt for y/N confirmation before executing. Pass `--yes` or `-y` to skip for scripting.
+- **Mattermost upgraded to 11.5.1** (was 9.11.0)
+- **Forgejo upgraded to 14.0.3** (was 9.0.0)
+
 ## [1.1.0] - 2026-03-27
 
 ### Added

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -171,18 +171,20 @@ The agent daemon manages agent lifecycles, message routing, and health monitorin
 | Command | What it does |
 |---------|-------------|
 | `./scripts/masonctl start` | Start MASON |
-| `./scripts/masonctl stop` | Stop MASON |
-| `./scripts/masonctl restart` | Restart everything |
+| `./scripts/masonctl stop` | Stop MASON (prompts for confirmation) |
+| `./scripts/masonctl restart` | Restart everything (prompts for confirmation) |
 | `./scripts/masonctl status` | Check what's running |
 | `./scripts/masonctl token` | Print your dashboard auth token |
 | `./scripts/masonctl login` | Print token and open dashboard in browser |
 | `./scripts/masonctl logs` | View logs |
 | `./scripts/masonctl logs -f` | Follow logs in real time |
 | `./scripts/masonctl pull` | Pull the latest MASON image from the registry |
-| `./scripts/masonctl update` | Pull latest image and restart the container |
-| `./scripts/masonctl rm` | Remove the container (keeps data) |
-| `./scripts/masonctl rm --data` | Remove the container **and** all persistent data |
+| `./scripts/masonctl update` | Pull latest image and restart (prompts for confirmation) |
+| `./scripts/masonctl rm` | Remove the container, keeps data (prompts for confirmation) |
+| `./scripts/masonctl rm --data` | Remove the container **and** all persistent data (prompts for confirmation) |
 | `./scripts/masonctl verify` | Check file integrity inside the container |
+
+> **Scripting tip:** Pass `--yes` or `-y` to skip confirmation prompts: `./scripts/masonctl stop --yes`
 
 ## Third-Party Dependencies
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -211,18 +211,20 @@ The simulation runs as long as the container is up. Agents keep working, collabo
 | Command | What it does |
 |---------|-------------|
 | `./scripts/masonctl start` | Start the MASON container |
-| `./scripts/masonctl stop` | Stop the container (agents will need to be brought back — see [Restarting](#restarting-mason)) |
-| `./scripts/masonctl restart` | Restart everything (only Connie auto-resumes — tell her to bring the team back) |
+| `./scripts/masonctl stop` | Stop the container — prompts for confirmation (agents will need to be brought back — see [Restarting](#restarting-mason)) |
+| `./scripts/masonctl restart` | Restart everything — prompts for confirmation (only Connie auto-resumes — tell her to bring the team back) |
 | `./scripts/masonctl status` | Check what's running |
 | `./scripts/masonctl token` | Print your dashboard auth token |
 | `./scripts/masonctl login` | Print token and open dashboard in browser |
 | `./scripts/masonctl logs` | View logs |
 | `./scripts/masonctl logs -f` | Follow logs in real time |
 | `./scripts/masonctl pull` | Pull the latest MASON image from the registry |
-| `./scripts/masonctl update` | Pull latest image and restart |
-| `./scripts/masonctl rm` | Remove the container (keeps data) |
-| `./scripts/masonctl rm --data` | Remove the container **and** all persistent data |
+| `./scripts/masonctl update` | Pull latest image and restart — prompts for confirmation |
+| `./scripts/masonctl rm` | Remove the container (keeps data) — prompts for confirmation |
+| `./scripts/masonctl rm --data` | Remove the container **and** all persistent data — prompts for confirmation |
 | `./scripts/masonctl verify` | Check file integrity inside the container |
+
+> **Scripting tip:** Destructive commands (stop, restart, update, rm) prompt for y/N confirmation. Pass `--yes` or `-y` to skip the prompt: `./scripts/masonctl stop --yes`
 
 For the full command reference, see [CONFIGURATION.md](CONFIGURATION.md#useful-commands).
 


### PR DESCRIPTION
## Summary

Per Kenji's heads up on 4 changes that landed today:

- **masonctl safety prompts**: All destructive commands prompt y/N. Added to both command tables + scripting tip for `--yes` flag.
- **Mattermost 11.5.1 / Forgejo 14.0.3**: Version bumps noted in changelog
- **v1.2.0 changelog entry**: Safety prompts + service upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)