### PR TITLE
Add CONTAINER_PHILOSOPHY.md and Dockerfile.reference

### DIFF
--- a/CONTAINER_PHILOSOPHY.md
+++ b/CONTAINER_PHILOSOPHY.md
@@ -1,0 +1,93 @@
+<!--
+Copyright (c) 2025-2026 Human Loop Ventures, LLC. All rights reserved.
+Use of this source code is governed by the Business Source License 1.1
+included in the LICENSE file at the root of this repository.
+-->
+
+# Container Philosophy
+
+The MASON Teams container is the only artifact we ship. It bundles a chat server, a git forge, a vector database, agent tooling, and the MASON web UI into one image. This page explains why it's shaped the way it is, what we promise about the contents, and what we deliberately don't.
+
+A sanitized reference of the build is in [`Dockerfile.reference`](./Dockerfile.reference).
+
+## Why a container
+
+The bar we set for ourselves is one command from "I want to try this" to "agents are talking." Everything else flows from that.
+
+A container is the smallest unit that makes "one command" possible across macOS, Linux, and Windows hosts. It pins versions, isolates state, gives us a single rollback point, and lets us assume the runtime environment is exactly what we built against — no "works on my machine" failures from a slightly different Python, a missing libsecret, or a stale Node. Reinstalling MASON Teams is a `docker rm` away.
+
+We treat the container as the product, not a packaging convenience. Everything we change is delivered through it.
+
+## Why "bundled" services
+
+MASON Teams runs Mattermost, Forgejo, ttyd, Qdrant, PostgreSQL, and our own services side-by-side in a single image. That's intentional, even though it makes the image larger than people sometimes expect.
+
+The alternative — five separate containers wired together with a Compose stack — would force users to think about networks, depends_on, health gates, persistent volumes per service, and version compatibility between services. Each one of those is a place a new user gets stuck.
+
+We pay the cost of a larger image so users don't pay the cost of integrating services that aren't really separable for our use case. Agents need chat to coordinate, git to commit, memory to recall, and a terminal to work in. Splitting those across containers makes the user assemble what we should be delivering.
+
+This is also why we don't expose pluggability for the bundled services. You can't swap our Mattermost for Slack or our Forgejo for GitHub — the agents are wired to the bundle, and breaking that boundary is a separate, larger project.
+
+## Ephemeral container, persistent volumes
+
+The container itself is meant to be disposable. The volume isn't.
+
+Everything stateful — Mattermost data, Forgejo repos, agent workspaces, generated credentials, the PostgreSQL cluster, the Qdrant vector store — lives under a single `/data` mount. When you `docker rm` the container and `docker run` a fresh one with the same volume, you pick up exactly where you left off. When you `docker rm -v`, you start clean.
+
+That split is deliberate. The container is for the runtime: binaries, system packages, tmux config, fonts, the entrypoint script. The volume is for what you've built: messages, repos, agent state, memory. We can ship a new image without anyone's data migrating; you can wipe state without reinstalling.
+
+If you're operating MASON Teams long-term, treat the volume as the only thing worth backing up.
+
+## Agent-first design
+
+MASON Teams is built so its agents are first-class operators of their own environment. Every workflow that exists for a human also exists as something an agent can execute: there are no GUI-only paths to managing the container, no manual steps wedged into otherwise automated flows.
+
+Concretely, that means:
+
+- The container exposes CLI tools (not just an API) for every lifecycle operation an agent or operator needs to perform.
+- Configuration is files, not forms. Agents read and write files reliably; that's our most universal automation primitive.
+- The web UI is a view onto the same state that agents manipulate. It never holds state the CLI can't reach.
+
+This is the principle that constrains a lot of design choices that might otherwise drift toward "easier for the human, harder for the agent."
+
+## Security boundaries
+
+The container is designed as a **single-user, localhost-only** development environment. The threat model assumes the host is trusted and the container runs on Docker Desktop. Details on the auth and exposure model live in [SECURITY.md](./SECURITY.md); this section covers what the *container* contributes.
+
+- **Non-root by default.** Every process inside the container runs as the unprivileged `mason` user (UID 1000). The image does not run as root.
+- **`sudo` inside the container is intentional.** The `mason` user has passwordless sudo so agents can install packages they discover they need during a session. The container is ephemeral; that compromise of least-privilege is bounded by the container lifetime and by the host-only network exposure.
+- **Three published ports.** Only `8080` (web UI), `8065` (Mattermost), and `3000` (Forgejo) are EXPOSEd. The terminal proxy, the vector database, and the daemon's control plane stay internal to the container.
+- **Build provenance.** Since v1.5.x, every published image on Docker Hub ships with SBOM (Software Bill of Materials) and provenance attestations. You can audit what's in any tag with `docker buildx imagetools inspect masonteams/mason-teams:<tag> --format '{{json .Provenance}}'`.
+- **Tini as PID 1.** Signal forwarding and zombie reaping are handled by `tini`, not bash. `docker stop` gives every internal service the chance to shut down cleanly.
+- **Integrity manifest.** The image ships with a manifest of every binary it installs, generated at build time. The `mason-verify` tool inside the container compares the installed files against that manifest at startup — tampering with the image fails the verification step.
+
+## What we promise, what we don't
+
+This is the section that matters most if you're depending on MASON Teams for anything beyond exploration. We're still in beta. Read this before you build a workflow that breaks when we ship.
+
+**What's stable across minor releases:**
+
+- **Published port numbers** (`8080`, `8065`, `3000`). If we change these, it's a major-version event.
+- **The `/data` volume layout at the top level** (`/data/mattermost`, `/data/forgejo`, `/data/agents`, etc.). Subtree contents may change as the underlying services upgrade.
+- **The `masonctl start`-level interface** — the user-facing CLI commands, their flags, their exit codes. We treat these like a public API.
+- **The dashboard auth model** (token at `~/.mason/token`, `mason_token` cookie). Documented in [SECURITY.md](./SECURITY.md); not silently changed.
+- **The image tag scheme.** `masonteams/mason-teams:stable` always points at the latest production release. `:vX.Y.Z` tags are immutable.
+
+**What's deliberately not stable and will change without ceremony:**
+
+- **The internal binary layout.** Which Go binaries we build, what they're named, which paths they live at inside `/usr/local/bin`. If you script against the container's internals, expect breakage.
+- **The persona, skill, and template content** baked into the image. These are how agents behave; we tune them constantly. They are not an API.
+- **Service versions** (Mattermost, Forgejo, Qdrant, Node, Python). We pin and upgrade these as part of routine maintenance.
+- **The internal port assignments** for non-EXPOSE'd services (Qdrant on 6333, daemon on 9090, ttyd on 7681). Don't rely on these from outside the container.
+- **Anything inside the container's filesystem outside `/data`.** Treat the image as opaque except for what's documented.
+
+**The general principle:** if you can reach it without `docker exec`, we treat it as an interface. If you have to `docker exec` to find it, treat it as an implementation detail.
+
+If something on the "stable" list needs to change, it goes through a deprecation cycle with a `Deprecation` HTTP header (where applicable) and a CHANGELOG entry one minor version ahead of the actual change. If something on the "not stable" list breaks for you, please [open an issue](https://github.com/Mason-Teams/mason-teams/issues) — we want to know, but the fix may be "your workflow shouldn't have depended on that."
+
+## Further reading
+
+- [Dockerfile.reference](./Dockerfile.reference) — sanitized reference of the actual build
+- [SECURITY.md](./SECURITY.md) — auth, exposure model, token handling
+- [CONFIGURATION.md](./CONFIGURATION.md) — environment variables and runtime options
+- [WORKFLOWS.md](./WORKFLOWS.md) — what agents actually do inside the container

--- a/Dockerfile.reference
+++ b/Dockerfile.reference
@@ -1,0 +1,245 @@
+# Copyright (c) 2025-2026 Human Loop Ventures, LLC. All rights reserved.
+# Use of this source code is governed by the Business Source License 1.1
+# included in the LICENSE file at the root of this repository.
+
+# =============================================================================
+# MASON Teams — Reference Dockerfile
+# =============================================================================
+#
+# This file is a sanitized reference of the Dockerfile used to build the
+# official `masonteams/mason-teams` image on Docker Hub. It exists so users,
+# security reviewers, and operators can see what's inside the container
+# without having to inspect the running image.
+#
+# It is NOT a buildable artifact. The actual build pulls source from the
+# internal MASON Teams source repository, which is not public. Lines that
+# would copy proprietary binaries are collapsed into placeholder COPY blocks
+# annotated `[INTERNAL BUILD STAGE]`. If you want to build your own image,
+# substitute those stages with your own build pipeline and binaries.
+#
+# Anything you see in this file matches the runtime structure of the
+# published image. The build is multi-arch (linux/amd64, linux/arm64) and
+# every release includes SBOM + provenance attestations on Docker Hub.
+#
+# Last reviewed against internal Dockerfile: see image label
+#   `org.opencontainers.image.revision` on the published image for the
+#   exact source commit a given tag was built from.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Stage 1: Build Go binaries [INTERNAL BUILD STAGE]
+# -----------------------------------------------------------------------------
+# In the real build this stage compiles MASON's Go binaries (web server,
+# daemon, agent lifecycle tools, MCP servers, integrity helpers) from
+# proprietary source. Reproduced here only to show base image + invariants.
+
+FROM golang:1.26-alpine AS builder
+WORKDIR /build
+RUN apk add --no-cache git
+# COPY go.mod go.sum ./
+# RUN go mod download
+# COPY . .
+# RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w \
+#       -X main.Version=$(cat VERSION) \
+#       -X main.Commit=$(git rev-parse --short HEAD) \
+#       -X main.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+#       -o /mason ./cmd/mason
+# (... additional binaries omitted; all built with the same flags ...)
+
+# -----------------------------------------------------------------------------
+# Stage 2: Build forgejo-mcp [COMMODITY]
+# -----------------------------------------------------------------------------
+# Forgejo's MCP server, built from public source. Provides agents a tool
+# interface to the bundled Forgejo instance.
+
+FROM golang:1.26-alpine AS forgejo-mcp-builder
+RUN apk add --no-cache git
+# RUN go install codeberg.org/<upstream>/forgejo-mcp@<pinned-version>
+
+# -----------------------------------------------------------------------------
+# Stage 3: Downloader [COMMODITY]
+# -----------------------------------------------------------------------------
+# Fetches the open-source services we bundle: Mattermost (chat), Forgejo
+# (git forge), ttyd (terminal-over-WebSocket), Qdrant (vector DB). Each is
+# pinned to a specific version; provenance is attested at publish time.
+
+FROM alpine:3.23 AS downloader
+RUN apk add --no-cache curl tar
+# Pin every artifact. Hashes are checked in the real build.
+# RUN curl -fsSL -o /opt/mattermost.tar.gz "https://.../mattermost-<version>-linux-<arch>.tar.gz"
+# RUN curl -fsSL -o /opt/forgejo        "https://.../forgejo-<version>-linux-<arch>"
+# RUN curl -fsSL -o /opt/ttyd           "https://.../ttyd.<arch>"
+# RUN curl -fsSL -o /opt/qdrant.tar.gz  "https://.../qdrant-<version>-<arch>-unknown-linux-musl.tar.gz"
+
+# -----------------------------------------------------------------------------
+# Stage 4: Runtime — what actually ships
+# -----------------------------------------------------------------------------
+# Debian slim with a pinned digest. Everything below this point is exactly
+# what's in the published image (modulo the proprietary COPY collapse).
+
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.opencontainers.image.title="MASON Teams" \
+      org.opencontainers.image.description="Multi-Agent Simulation Orchestration Network" \
+      org.opencontainers.image.source="https://github.com/Mason-Teams/mason-teams" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}"
+
+# Runtime dependencies. Roughly grouped by purpose; comments explain why
+# each non-obvious package is in the image.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    bash curl git jq tmux tini ca-certificates tzdata \
+    postgresql postgresql-contrib \
+    ripgrep \
+    # Python — runs a memory MCP server used for agent memory.
+    python3 python3-pip python3-venv \
+    # Credential storage via libsecret. Used by Claude Code and MASON's
+    # own secret-management package for tokens that shouldn't sit in files.
+    libsecret-1-0 libsecret-tools gnome-keyring dbus \
+    # In-container log collection so health-check has a fallback.
+    busybox-syslogd \
+    # Font management for Nerd Font glyphs. Agents parse tmux output,
+    # which means terminal glyphs need to render correctly server-side.
+    fontconfig \
+    # Process inspection — agents introspect their own and others' state.
+    procps \
+    # Arithmetic in shell — used for things like jittered office-hours delays.
+    bc \
+    # Sudo for in-container package installs during interactive sessions.
+    # The mason user has NOPASSWD; the container is ephemeral, so risk is low.
+    sudo \
+    # Network diagnostics for agent troubleshooting.
+    iproute2 net-tools iputils-ping dnsutils lsof strace \
+    # General utilities.
+    less vim-tiny htop wget file unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 LTS. Debian's default Node 18 has stdio pipe-handling bugs
+# that cause MCP tool drops in Claude Code; Node 22+ resolves them.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# MesloLGS Nerd Font — needed server-side for correct rendering of
+# Braille spinners, box-drawing, block elements, and Powerline glyphs
+# in agent-generated terminal output that downstream tools parse.
+RUN mkdir -p /usr/local/share/fonts/MesloLGSNF && \
+    curl -fsSL -o "/usr/local/share/fonts/MesloLGSNF/MesloLGS NF Regular.ttf" \
+      "https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Regular.ttf" && \
+    fc-cache -fv
+
+# Memory MCP server. Installed from a private package index; the package
+# itself is internal and is referenced here as `<memory-mcp-package>` for
+# transparency. Pulls embedding models (ONNX via fastembed) and connects to
+# the bundled Qdrant via HTTP API. [INTERNAL DEPENDENCY]
+RUN pip3 install --break-system-packages --upgrade pip setuptools && \
+    pip3 install --break-system-packages \
+    --extra-index-url <internal-package-index> \
+    "<memory-mcp-package>" \
+    mkdocs-material
+
+# Non-root user with bash + passwordless sudo (see comment above).
+RUN useradd -m -u 1000 -s /bin/bash mason \
+    && echo "mason ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/mason \
+    && chmod 0440 /etc/sudoers.d/mason
+
+# Directory layout for stateful services and shared assets.
+RUN mkdir -p /data/mattermost /data/forgejo /data/agents /data/credentials \
+             /data/postgres /data/qdrant/storage /data/crontab \
+    && mkdir -p /opt/mattermost /opt/forgejo \
+    && mkdir -p /app/web \
+    && mkdir -p /run/postgresql /run/dbus \
+    && chown -R mason:mason /data /app /run/postgresql /run/dbus
+
+# MASON binaries (proprietary). The real build pulls ~15 statically-linked
+# Go binaries from the builder stage — the web server, agent lifecycle
+# tools, the daemon, MCP servers, and integrity helpers. All land in
+# /usr/local/bin and run as the `mason` user.
+# [INTERNAL BUILD STAGE]
+# COPY --from=builder /<binary> /usr/local/bin/<binary>   (×N)
+
+# Bundled open-source services.
+COPY --from=downloader /opt/mattermost /opt/mattermost
+RUN chown -R mason:mason /opt/mattermost
+COPY --from=downloader /opt/forgejo /usr/local/bin/forgejo
+RUN chmod +x /usr/local/bin/forgejo
+COPY --from=forgejo-mcp-builder /go/bin/forgejo-mcp /usr/local/bin/forgejo-mcp
+RUN chmod +x /usr/local/bin/forgejo-mcp
+COPY --from=downloader /opt/ttyd /usr/local/bin/ttyd
+COPY --from=downloader /opt/qdrant /usr/local/bin/qdrant
+
+# Web UI assets and persona/skill templates. See CONTAINER_PHILOSOPHY.md
+# for what these contain and why they ship inside the image.
+# [INTERNAL BUILD STAGE]
+# COPY --from=builder /build/web /app/web
+# COPY --from=builder /build/docs/personas /app/docs/personas
+# COPY --from=builder /build/scripts/claude-user-level/ /home/mason/.claude/
+# COPY --from=builder /build/scripts/claude-commands/   /home/mason/.claude/commands/
+RUN mkdir -p /home/mason/.claude/commands /app/templates /app/docs/personas \
+    && chown -R mason:mason /home/mason/.claude /app/templates /app/docs/personas
+
+# Documentation site (MkDocs). Built at image-build time so the running
+# container can serve it without pulling from the network.
+# COPY docs/ /app/docs-build/
+# RUN cd /app/docs-build && mkdocs build --site-dir /app/docs/site
+
+# Entrypoint and supporting scripts.
+# [INTERNAL BUILD STAGE — proprietary scripts]
+# COPY --chmod=755 scripts/entrypoint.sh         /usr/local/bin/entrypoint.sh
+# COPY --chmod=755 scripts/statusline-command.sh /usr/local/bin/statusline-command.sh
+# COPY --chmod=755 scripts/manifest-gen          /usr/local/bin/manifest-gen
+# COPY --chmod=755 scripts/mason-verify          /usr/local/bin/mason-verify
+
+# tmux configuration for 256-color/truecolor support. Without these
+# overrides, tmux defaults to `screen` (8 colors), which breaks the rich
+# terminal UIs that agents render and parse.
+RUN echo 'set-option -g default-terminal "tmux-256color"' > /etc/tmux.conf && \
+    echo 'set-option -ga terminal-overrides ",*256col*:RGB"' >> /etc/tmux.conf && \
+    echo 'set-option -ga terminal-overrides ",xterm-256color:Tc"' >> /etc/tmux.conf
+
+WORKDIR /app
+
+# Runtime environment.
+ENV MASON_CONTAINER=1
+ENV TERM=xterm-256color
+ENV COLORTERM=truecolor
+ENV LANG=C.UTF-8
+ENV PATH="/usr/local/bin:${PATH}"
+ENV PGDATA=/data/postgres
+ENV PGHOST=/run/postgresql
+ENV PGPORT=5432
+ENV MM_CONFIG=/data/mattermost/config.json
+ENV MM_DATA_DIR=/data/mattermost
+ENV FORGEJO_WORK_DIR=/data/forgejo
+ENV FORGEJO_CUSTOM=/data/forgejo/custom
+ENV FORGEJO_MCP_PATH=/usr/local/bin/forgejo-mcp
+# Memory MCP server connects to the bundled Qdrant via the internal HTTP API.
+ENV DIT_QDRANT_URL=http://localhost:6333
+
+# Build manifest used by `mason-verify` to catch tampering with shipped
+# binaries. Generated at the end of the build so it covers every COPY.
+# [INTERNAL BUILD STEP]
+# RUN GIT_COMMIT="${VCS_REF:-unknown}" manifest-gen --output /mason/manifest.json
+
+USER mason
+
+# Ports.
+# 8080 — MASON Teams web UI
+# 8065 — Mattermost
+# 3000 — Forgejo
+# Internal (not exposed by EXPOSE; reachable inside the container only):
+#   7681 — ttyd (proxied through the dashboard)
+#   6333 — Qdrant
+#   9090 — mason-daemon (localhost)
+EXPOSE 8080 8065 3000
+
+# Single persistent volume — everything stateful lives under /data.
+# See CONTAINER_PHILOSOPHY.md "Ephemeral container, persistent volumes."
+VOLUME ["/data"]
+
+# tini reaps zombies and forwards signals so the supervisor inside the
+# entrypoint can shut down its children cleanly on `docker stop`.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+CMD ["mason", "server", "--data=/data"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,8 @@ included in the LICENSE file at the root of this repository.
 
 MASON Teams is designed as a **single-user, localhost-only** development environment. Security controls protect against accidental exposure and unauthorized local access. The threat model assumes the host machine is trusted and the container runs on Docker Desktop.
 
+For the *container's* contribution to the security model — non-root runtime, port exposure, SBOM/provenance attestations, integrity manifest — see [CONTAINER_PHILOSOPHY.md → Security boundaries](./CONTAINER_PHILOSOPHY.md#security-boundaries). A sanitized reference of the build itself is in [`Dockerfile.reference`](./Dockerfile.reference).
+
 ## Authentication
 
 ### Dashboard


### PR DESCRIPTION
## Summary

Public-Dockerfile transparency play per the May 11 thread with dpark and Kenji. Adds two new files to the public repo plus a cross-link from SECURITY.md.

- **`CONTAINER_PHILOSOPHY.md`** (~100 lines) — principles-and-philosophy overview instead of a per-version component listing (per dpark: a component doc would rot too fast). Six timeless sections:
  1. Why a container
  2. Why bundled services (MM + Forgejo + Qdrant + tooling)
  3. Ephemeral container, persistent volumes
  4. Agent-first design (CLI access, files-as-API)
  5. Security boundaries (non-root, port surface, SBOM + provenance, integrity manifest, tini)
  6. **What we promise / what we don't** — weighted per Kenji's note. Declares the stable surface versus what's deliberately unstable. Preempts "v1.6 broke my X" complaints up front.

- **`Dockerfile.reference`** (~245 lines) — sanitized reference of the actual build. Same 4-stage shape, same apt-get list, same env/user/expose/entrypoint. IP-bearing COPY blocks collapsed to placeholder comments labeled `[INTERNAL BUILD STAGE]`. Internal infra references (homelab URLs, private package indexes) replaced with abstract placeholders. Header explicitly says "this is not a buildable artifact."

- **`SECURITY.md`** — one-paragraph cross-link to the new philosophy doc and reference Dockerfile.

## Test plan

- [x] No internal URL leaks (grep clean for homelab/internal/private hostnames)
- [x] Markdown renders correctly
- [x] Dockerfile.reference parses as a Dockerfile (reference, not buildable)
- [ ] Reviewers sanity-check Section 6 of CONTAINER_PHILOSOPHY — its promises become commitments

## Out of scope

- README/GETTING_STARTED cross-links — Riley owns those; happy to coordinate a follow-up
- Drift-detection CI between this reference and the internal Dockerfile

--marcus