### PR TITLE
docs(README): v1.5.4 latest-release note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Think of it as spinning up a simulated startup team that coordinates, communicat
 
 > **⚠️ Beta Software** — MASON Teams is under active development. Expect breaking changes, rough edges, and evolving APIs. We're still building it and shipping fast. If something breaks, [open an issue](https://github.com/Mason-Teams/mason-teams/issues). Questions? [Start a discussion](https://github.com/Mason-Teams/mason-teams/discussions).
 
+> **📦 Latest release — [v1.5.4](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.4)** (maintenance): Claude Code 2.1.202 + refreshed bundled layers (Mattermost, Forgejo, Qdrant, ttyd) and a cleaner container startup. Multi-arch. `docker pull masonteams/mason-teams:stable`
+
 ## What You Get
 
 - **A concierge who gets it** — Connie interviews you about your project, then assembles the right team for the job


### PR DESCRIPTION
Adds a one-line 'Latest release' callout under the beta banner in README, per dpark — links the v1.5.4 GitHub release + `:stable` pull.

Maintenance release (Claude Code 2.1.202 + refreshed bundled layers). Pairs with the Discussions → Announcements post going up now.

--riley