### PR TITLE
docs(README): v1.5.6 latest-release note (security hardening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Think of it as spinning up a simulated startup team that coordinates, communicat
 
 > **⚠️ Beta Software** — MASON Teams is under active development. Expect breaking changes, rough edges, and evolving APIs. We're still building it and shipping fast. If something breaks, [open an issue](https://github.com/Mason-Teams/mason-teams/issues). Questions? [Start a discussion](https://github.com/Mason-Teams/mason-teams/discussions).
 
-> **📦 Latest release — [v1.5.4](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.4)** (maintenance): Claude Code 2.1.202 + refreshed bundled layers (Mattermost, Forgejo, Qdrant, ttyd) and a cleaner container startup. Multi-arch. `docker pull masonteams/mason-teams:stable`
+> **📦 Latest release — [v1.5.6](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.6)** (security hardening): cleared 17 of 18 critical CVEs — including a CVSS 10.0 in the bundled Mattermost — refreshed Mattermost/Forgejo/Qdrant, and restored agent access to Forgejo issue tools. Multi-arch. `docker pull masonteams/mason-teams:stable`
 
 ## What You Get
 


### PR DESCRIPTION
Updates the README 'Latest release' callout from v1.5.4 → **v1.5.6** (security-hardening release: 17/18 critical CVEs cleared incl. the CVSS 10.0 Mattermost one, refreshed bundled components, + the Forgejo issue-tool fix).

Pairs with the Discussions announcement (#49). Off current main.

--riley