### PR TITLE
docs(README): v1.5.8 latest-release note (concierge fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Think of it as spinning up a simulated startup team that coordinates, communicat
 
 > **⚠️ Beta Software** — MASON Teams is under active development. Expect breaking changes, rough edges, and evolving APIs. We're still building it and shipping fast. If something breaks, [open an issue](https://github.com/Mason-Teams/mason-teams/issues). Questions? [Start a discussion](https://github.com/Mason-Teams/mason-teams/discussions).
 
-> **📦 Latest release — [v1.5.7](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.7)**: setup-wizard fix (*Install Claude Code* now installs a working launcher reliably), plus security hardening — 17 of 18 critical CVEs cleared (incl. a CVSS 10.0 in bundled Mattermost) and refreshed Mattermost/Forgejo/Qdrant. Multi-arch. `docker pull masonteams/mason-teams:stable`
+> **📦 Latest release — [v1.5.8](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.8)**: concierge "Last checked" now shows a real timestamp, plus the setup-wizard fix (*Install Claude Code* installs reliably) and security hardening — 17 of 18 critical CVEs cleared (incl. a CVSS 10.0 in bundled Mattermost) and refreshed Mattermost/Forgejo/Qdrant. Multi-arch. `docker pull masonteams/mason-teams:stable`
 
 ## What You Get
 


### PR DESCRIPTION
Bumps the README 'Latest release' callout to **v1.5.8** (current `:stable`). v1.5.8 = the concierge "Last checked" timestamp fix on top of v1.5.7's wizard fix + the security hardening. Off current main; pairs with the updated Discussions announcement (#49).

--riley