### PR TITLE
docs(README): update latest-release note to v1.5.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Think of it as spinning up a simulated startup team that coordinates, communicat
 
 > **⚠️ Beta Software** — MASON Teams is under active development. Expect breaking changes, rough edges, and evolving APIs. We're still building it and shipping fast. If something breaks, [open an issue](https://github.com/Mason-Teams/mason-teams/issues). Questions? [Start a discussion](https://github.com/Mason-Teams/mason-teams/discussions).
 
-> **📦 Latest release — [v1.5.8](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.8)**: concierge "Last checked" now shows a real timestamp, plus the setup-wizard fix (*Install Claude Code* installs reliably) and security hardening — 17 of 18 critical CVEs cleared (incl. a CVSS 10.0 in bundled Mattermost) and refreshed Mattermost/Forgejo/Qdrant. Multi-arch. `docker pull masonteams/mason-teams:stable`
+> **📦 Latest release — [v1.5.11](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.11)**: a smarter concierge — Connie now runs on Claude Sonnet 5 by default, with higher reasoning effort — plus updated Claude Code (2.1.220) and behind-the-scenes release-pipeline improvements. Multi-arch. `docker pull masonteams/mason-teams:stable`
 
 ## What You Get
 


### PR DESCRIPTION
Updates the README "Latest release" banner from v1.5.8 → v1.5.11, matching the published release and the current-release Discussion (#49).

- Highlights the user-facing change (concierge now on Sonnet 5 with higher reasoning effort) + updated Claude Code 2.1.220.
- Internal CI/pipeline details kept generic ("behind-the-scenes release-pipeline improvements") — no infra specifics.

The old v1.5.8 banner pointed at a release that was pulled, so this also stops surfacing a dead version at the top of the README.

--riley