### PR TITLE
docs(README): revise v1.5.11 banner to all-agents Sonnet 5 framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Think of it as spinning up a simulated startup team that coordinates, communicat
 
 > **⚠️ Beta Software** — MASON Teams is under active development. Expect breaking changes, rough edges, and evolving APIs. We're still building it and shipping fast. If something breaks, [open an issue](https://github.com/Mason-Teams/mason-teams/issues). Questions? [Start a discussion](https://github.com/Mason-Teams/mason-teams/discussions).
 
-> **📦 Latest release — [v1.5.11](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.11)**: a smarter concierge — Connie now runs on Claude Sonnet 5 by default, with higher reasoning effort — plus updated Claude Code (2.1.220) and behind-the-scenes release-pipeline improvements. Multi-arch. `docker pull masonteams/mason-teams:stable`
+> **📦 Latest release — [v1.5.11](https://github.com/Mason-Teams/mason-teams/releases/tag/v1.5.11)**: all MASON agents now default to the **Claude Sonnet 5** model, with higher reasoning effort and extended thinking on, plus Claude Code updated to 2.1.220. Multi-arch. `docker pull masonteams/mason-teams:stable`
 
 ## What You Get
 


### PR DESCRIPTION
Follow-up to #54, per dpark's emphasis correction.

Revises the "Latest release" banner to match the corrected public CHANGELOG (commit 206249b): **all MASON agents** now default to Sonnet 5 (not just the concierge), with higher reasoning effort and extended thinking, plus Claude Code 2.1.220. Also drops the internal release-pipeline mention that shouldn't be in the public banner.

Discussion #49 is aligned to the same framing.

--riley